### PR TITLE
Replaced sdl display with gtk display.

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -15,10 +15,10 @@ qemu-system-x86_64 \
     -smbios type=2 \
     -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0 \
     -serial mon:stdio \
-    -drive if=pflash,format=raw,readonly,file=packaged-firmware/OVMF_CODE.fd \
+    -drive if=pflash,format=raw,readonly=on,file=packaged-firmware/OVMF_CODE.fd \
     -drive if=pflash,format=raw,file=firmware/OVMF_VARS-1024x768.fd \
     -device virtio-vga-gl \
-    -display sdl,gl=on \
+    -display gtk,gl=on \
     -vga std \
     -L /usr/share/seabios/ \
     -L /usr/lib/ipxe/qemu/ \

--- a/launch-macos.sh
+++ b/launch-macos.sh
@@ -15,10 +15,10 @@ qemu-system-x86_64 \
     -smbios type=2 \
     -object rng-random,id=rng0,filename=/dev/urandom -device virtio-rng-pci,rng=rng0 \
     -serial mon:stdio \
-    -drive if=pflash,format=raw,readonly,file=packaged-firmware/OVMF_CODE.fd \
+    -drive if=pflash,format=raw,readonly=on,file=packaged-firmware/OVMF_CODE.fd \
     -drive if=pflash,format=raw,file=firmware/OVMF_VARS-1024x768.fd \
     -device virtio-vga-gl \
-    -display sdl,gl=on \
+    -display gtk,gl=on \
     -vga std \
     -L /usr/share/seabios/ \
     -L /usr/lib/ipxe/qemu/ \


### PR DESCRIPTION
- Replaced sdl display with gtk display
- Updated drive option to readonly=on
- Tested on 5.18.9-arch1-1 SMP PREEMPT_DYNAMIC with QEMU emulator version 7.0.0